### PR TITLE
Avoid rebuilding cache when the primary model has been destroyed

### DIFF
--- a/lib/thermos/notifier.rb
+++ b/lib/thermos/notifier.rb
@@ -5,7 +5,7 @@ module Thermos
     extend ActiveSupport::Concern
 
     included do
-      after_commit :notify_thermos
+      after_commit :notify_thermos, on: %i[create update]
     end
 
     private

--- a/test/thermos_test.rb
+++ b/test/thermos_test.rb
@@ -111,6 +111,23 @@ class ThermosTest < ActiveSupport::TestCase
     assert_raises(MockExpectationError) { mock.verify }
   end
 
+  test "does not rebuild the cache on primary model destroy" do
+    mock = Minitest::Mock.new
+    category = categories(:baseball)
+
+    Thermos.fill(key: "key", model: Category) do |id|
+      mock.call(id)
+    end
+
+    mock.expect(:call, 1, [category.id])
+    assert_equal 1, Thermos.drink(key: "key", id: category.id)
+    mock.verify
+
+    mock.expect(:call, 2, [category.id])
+    category.destroy!
+    assert_raises(MockExpectationError) { mock.verify }
+  end
+
   test "pre-builds cache for new primary model records" do
     mock = Minitest::Mock.new
 


### PR DESCRIPTION
#### Summary

Restrict the queueing of `RefillJob` to only happen on `create` and `update` events, avoid queueing the job on destroy.

Thermos uses globalid serialization for the `ActiveJob` params when available, to serialize the `self` instance variable to the queue backend, which is then automatically deserialized by Rails / ActiveJob, [reference](https://edgeguides.rubyonrails.org/active_job_basics.html#globalid).

For any records that were destroyed, the serialization will happen without an issue with the in-memory instance of the model, but during deserialization by the background job worker, the record will not be available causing the `RefillJob` to fail.

Potential Improvement:
* Instead of avoiding queueing the job, we can also clear any existing data from cache from the record.