### PR TITLE
Allowing filtering on the primary model when a dependency has changed

### DIFF
--- a/lib/thermos/beverage.rb
+++ b/lib/thermos/beverage.rb
@@ -19,9 +19,15 @@ module Thermos
       @deps.select do |dep|
         dep.klass == dep_model.class
       end.flat_map do |dep|
+        lookup_keys = []
+
         @model.joins(dep.path)
               .where(dep.table => { id: dep_model.id })
-              .pluck(@lookup_key)
+              .find_each do |model|
+                lookup_keys << model.send(@lookup_key) if should_fill?(model)
+              end
+
+        lookup_keys
       end.uniq
     end
 

--- a/lib/thermos/refill_job.rb
+++ b/lib/thermos/refill_job.rb
@@ -17,10 +17,8 @@ module Thermos
 
     def refill_dependency_caches(model)
       BeverageStorage.instance.beverages.each do |beverage|
-        if beverage.should_fill?(model)
-          beverage.lookup_keys_for_dep_model(model).each do |lookup_key|
-            Thermos::RebuildCacheJob.perform_later(beverage.key, lookup_key)
-          end
+        beverage.lookup_keys_for_dep_model(model).each do |lookup_key|
+          Thermos::RebuildCacheJob.perform_later(beverage.key, lookup_key)
         end
       end
     end

--- a/lib/thermos/version.rb
+++ b/lib/thermos/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Thermos
-  VERSION = '0.5.1'
+  VERSION = '0.5.2'
 end

--- a/test/dummy/app/models/category.rb
+++ b/test/dummy/app/models/category.rb
@@ -3,6 +3,10 @@ class Category < ActiveRecord::Base
   has_many :products, through: :category_items
   belongs_to :store
 
+  def ball?
+    name.match("ball")
+  end
+
   def as_json(*args)
     {
       name: name,

--- a/test/fixtures/stores.yml
+++ b/test/fixtures/stores.yml
@@ -1,2 +1,4 @@
 sports:
   name: sports store
+supermarket:
+  name: supermarket store


### PR DESCRIPTION
#### Summary

This fixes a couple of bugs around filters, bumps version to 0.5.2.

##### Issue 1

When there are multiple beverages configured, and one of the beverages has a filter that uses custom filtering logic specific to that model, we run into an error when `RefillJob#refill_dependency_caches` is called.

The filter proc would fail for the other beverages, say Category and Store are the beverages and we have a filter on Category, `Category#ball?`, when store is updated, `store.ball?` will throw an exception.

##### Issue 2

To fix Issue 1, we need to move the `beverage.should_fill?` call from `RefillJob#refill_dependency_caches`. And, to accurately filter on the parent model instead of on the dependent model we need to load the parent model first and then run `should_fill?` on the parent.

This modified the existing query would only loads the `lookup_key` from the DB. Instead, we need to instantiate the object and only select the items that pass the filter criteria.

Depending on how many records are loaded for the dependency, this could introduce a performance issue.